### PR TITLE
fix compile issue 20

### DIFF
--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -16,7 +16,8 @@ def copytree(src, dst, symlinks=False, ignore=None):
 			shutil.copy2(item, dst / item.name)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
+	envdefs = env['CPPDEFINES'].copy()
+	for define in envdefs:
 		if define[0] == field:
 			env['CPPDEFINES'].remove(define)
 	env['CPPDEFINES'].append((field, value))


### PR DESCRIPTION
### Related Issues

https://github.com/tronxy3d/F4xx-SIM480x320/issues/20

sadly still get after in the docker file
```
/code/.platformio2/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: Marlin/muyu/libmuyu.a(muyu.cpp.o): in function `EXTI2_IRQHandler':
F:\YSZ\Work\3Firmware-2.1.1/Marlin\muyu/muyu.cpp:67: multiple definition of `EXTI2_IRQHandler'; .pio/build/tronxy_stm32f103/SrcWrapper/src/stm32/interrupt.cpp.o:/code/.platformio2/packages/framework-arduinoststm32/libraries/SrcWrapper/src/stm32/interrupt.cpp:349: first defined here
collect2: error: ld returned 1 exit status
*** [.pio/build/tronxy_stm32f103/firmware.elf] Error 1
```